### PR TITLE
Add gemv/gemm dispatch optimizations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: rust
 rust:
   - nightly
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y gfortran

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ serde = { version = "1.0.24", features = ["rc"] }
 serde_derive = "1.0.24"
 stdsimd = "0.0.3"
 
+[dev-dependencies]
+ndarray = { version = "0.11.0", features = ["blas", "serde-1"] }
+blas-src = { version = "0.1.2", default-features = false, features = ["openblas"] }
+openblas-src = { version = "0.5.6", default-features = false, features = ["static"] }
+
 [profile.bench]
 lto = true
 debug = true

--- a/src/nn/lstm.rs
+++ b/src/nn/lstm.rs
@@ -23,7 +23,7 @@
 //! // Initialize the parameters.
 //! let parameters = lstm::Parameters::new(input_dim, hidden_dim);
 //! let lstm = parameters.build();
-//! 
+//!
 //! // Construct the input nodes.
 //! let input: Vec<_> = (0..200)
 //!                      .map(|_| InputNode::new(xavier_normal(1, input_dim))).collect();

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 
 use ndarray;
 use ndarray::Axis;
-use ndarray::linalg::general_mat_mul;
 
 use smallvec::SmallVec;
 
@@ -972,7 +971,7 @@ where
         self.lhs.forward();
         self.rhs.forward();
 
-        general_mat_mul(
+        numerics::mat_mul(
             1.0,
             self.lhs.value().deref(),
             self.rhs.value().deref(),
@@ -991,8 +990,14 @@ where
                 let mut lhs_gradient = self.lhs_gradient.borrow_mut();
                 let mut rhs_gradient = self.rhs_gradient.borrow_mut();
 
-                general_mat_mul(1.0, gradient, &rhs_value.t(), 0.0, &mut lhs_gradient);
-                general_mat_mul(1.0, &lhs_value.t(), gradient, 0.0, &mut rhs_gradient);
+                numerics::mat_mul(1.0, gradient, &rhs_value.t(), 0.0, &mut lhs_gradient);
+                numerics::mat_mul(
+                    1.0,
+                    &lhs_value.t(),
+                    gradient.deref(),
+                    0.0,
+                    &mut rhs_gradient,
+                );
             }
         }
 
@@ -1888,7 +1893,7 @@ where
         }
 
         {
-            general_mat_mul(
+            numerics::mat_mul(
                 1.0,
                 gradient,
                 jacobian.deref_mut(),


### PR DESCRIPTION
Currently, BLAS gemv is not triggered if M is not row-major, making
vector-matrix operations around 3x slower than they should be if gemv
were called correctly. This is an issue in ndarray (opened an issue upstream).