### PR TITLE
Fix hogwild param safety.

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -537,12 +537,12 @@ impl HogwildParameter {
         }
     }
 
-    pub fn value(&self) -> Ref<Arr> {
-        self.value.borrow()
+    pub fn value(&self) -> &Arr {
+        unsafe { & *(self.value.as_ptr()) }
     }
 
-    pub fn squared_gradients(&self) -> Ref<Arr> {
-        self.squared_gradients.borrow()
+    pub fn squared_gradients(&self) -> &Arr {
+        unsafe { & *(self.squared_gradients.as_ptr()) }
     }
 
     pub(crate) unsafe fn value_mut(&self) -> &mut Arr {

--- a/src/numerics.rs
+++ b/src/numerics.rs
@@ -4,7 +4,7 @@ use stdsimd;
 use ndarray::{ArrayBase, Axis, Data, DataMut, Ix1, Ix2};
 use ndarray::linalg::{general_mat_mul, general_mat_vec_mul};
 
-use fast_approx::{fastexp, fastlog, tanhf_fast, fastpow2};
+use fast_approx::{fastexp, fastlog, tanhf_fast};
 
 use super::Arr;
 


### PR DESCRIPTION
Don't use borrow when parameters can be shared across threads.